### PR TITLE
Add Docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+.git
+.gitignore
+dist
+coverage
+reports
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.DS_Store
+.vscode
+.idea
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+CMD ["node", "dist/index.js"]

--- a/README.en.md
+++ b/README.en.md
@@ -83,6 +83,17 @@ Run the unit and integration tests:
 npm run test
 ```
 
+## Docker Usage
+Build the image:
+```bash
+docker build -t dgii-ecf .
+```
+Run the container:
+```bash
+docker run --rm dgii-ecf
+```
+
+
 ## Links & Documentation
 - [DGII Official Documentation](https://dgii.gov.do/cicloContribuyente/facturacion/comprobantesFiscalesElectronicosE-CF/Paginas/default.aspx)
 - [DGII Technical Docs](https://dgii.gov.do/cicloContribuyente/facturacion/comprobantesFiscalesElectronicosE-CF/Paginas/documentacionSobreE-CF.aspx)

--- a/README.es.md
+++ b/README.es.md
@@ -83,6 +83,17 @@ Ejecute las pruebas unitarias e integradas:
 npm run test
 ```
 
+## Uso con Docker
+Construir la imagen:
+```bash
+docker build -t dgii-ecf .
+```
+Ejecutar el contenedor:
+```bash
+docker run --rm dgii-ecf
+```
+
+
 ## Enlaces y Documentación
 - [Documentación Oficial DGII](https://dgii.gov.do/cicloContribuyente/facturacion/comprobantesFiscalesElectronicosE-CF/Paginas/default.aspx)
 - [Documentación Técnica DGII](https://dgii.gov.do/cicloContribuyente/facturacion/comprobantesFiscalesElectronicosE-CF/Paginas/documentacionSobreE-CF.aspx)


### PR DESCRIPTION
## Summary
- add Dockerfile using Node 20
- ignore build artifacts in `.dockerignore`
- document container usage in English and Spanish READMEs

## Testing
- `npm ci`
- `npm test` *(fails: ENOENT certificates)*
- `docker build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e6fbea0c8329848d8d56fc9f6f97