### PR TITLE
Add ERP integration documentation

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -93,6 +93,9 @@ Run the container:
 docker run --rm dgii-ecf
 ```
 
+## ERP Integration
+For a detailed guide on how to embed **dgii-ecf** into your ERP system, see [docs/ERP_Integration_Guide.en.md](docs/ERP_Integration_Guide.en.md).
+
 
 ## Links & Documentation
 - [DGII Official Documentation](https://dgii.gov.do/cicloContribuyente/facturacion/comprobantesFiscalesElectronicosE-CF/Paginas/default.aspx)

--- a/README.es.md
+++ b/README.es.md
@@ -93,6 +93,9 @@ Ejecutar el contenedor:
 docker run --rm dgii-ecf
 ```
 
+## Integración con ERP
+Para una guía detallada de cómo incorporar **dgii-ecf** dentro de su sistema ERP, consulte [docs/Guia_Integracion_ERP.es.md](docs/Guia_Integracion_ERP.es.md).
+
 
 ## Enlaces y Documentación
 - [Documentación Oficial DGII](https://dgii.gov.do/cicloContribuyente/facturacion/comprobantesFiscalesElectronicosE-CF/Paginas/default.aspx)

--- a/README.md
+++ b/README.md
@@ -3,4 +3,6 @@
 Documentation is available in multiple languages:
 
 - [English](README.en.md)
+- [ERP Integration Guide](docs/ERP_Integration_Guide.en.md)
+- [Guía de Integración con ERP](docs/Guia_Integracion_ERP.es.md)
 - [Español](README.es.md)

--- a/docs/ERP_Integration_Guide.en.md
+++ b/docs/ERP_Integration_Guide.en.md
@@ -1,0 +1,96 @@
+# ERP Integration Guide
+
+This document explains how to integrate **dgii-ecf** with any existing ERP system. It assumes your ERP already handles the sales workflow and you want to automate sending electronic fiscal documents (e-CF) to the DGII.
+
+## 1. Environment Preparation
+
+1. Install the library in the Node.js project used by your ERP:
+
+```bash
+npm install dgii-ecf
+```
+
+2. Make sure you have your digital certificate (.p12) and its password.
+
+## 2. Loading the Certificate
+
+Use `P12Reader` to load the private key and certificate used to sign XML.
+
+```ts
+import path from 'path';
+import { P12Reader } from 'dgii-ecf';
+
+const reader = new P12Reader('certificate_password');
+const certs = reader.getKeyFromFile(path.resolve(__dirname, 'certificate.p12'));
+```
+
+## 3. Authentication
+
+Before sending documents, obtain a valid token from DGII.
+
+```ts
+import { ECF } from 'dgii-ecf';
+
+const ecf = new ECF(certs);
+const tokenData = await ecf.authenticate();
+```
+
+Store `tokenData.token` according to your ERP's authentication logic and renew it when needed.
+
+## 4. Signing and Sending Documents
+
+Your ERP should generate the invoice XML according to DGII's standard. Once generated, use `Signature` to sign it and `ECF` to send it.
+
+```ts
+import fs from 'fs';
+import { Signature } from 'dgii-ecf';
+
+const xml = fs.readFileSync('invoice.xml', 'utf8');
+const signature = new Signature(certs.key!, certs.cert!);
+const signedXml = signature.signXml(xml, 'ECF');
+
+const response = await ecf.sendElectronicDocument(signedXml, 'RNCeNCF.xml');
+```
+
+Record the `trackId` and response status in your ERP for future reference.
+
+## 5. Status Inquiry
+
+To know the status of a previously sent document, use `statusTrackId`.
+
+```ts
+const status = await ecf.statusTrackId(trackId);
+```
+
+Integrate this information with your ERP's tracking or reporting modules.
+
+## 6. Handling Responses and Errors
+
+- Validate each operation's response and log any error codes in your ERP.
+- Implement retries or user notifications on network failures or invalid responses.
+
+## 7. DGII Environments
+
+Configure the environment according to the context (Development, Certification or Production).
+
+```ts
+import { ENVIRONMENT } from 'dgii-ecf';
+const ecf = new ECF(certs, ENVIRONMENT.PROD);
+```
+
+## 8. Best Practices
+
+- Keep integration logic in a separate module within the ERP.
+- Protect the private key and limit access to it.
+- Automate token renewal and certificate expiration control.
+
+## 9. Basic Flow Example
+
+1. The user registers the invoice in the ERP.
+2. The ERP generates the e-CF XML.
+3. The XML is signed using `Signature`.
+4. The document is sent with `ECF.sendElectronicDocument`.
+5. The response and `trackId` are stored.
+6. Periodically query the status with `statusTrackId` until confirmation is received.
+
+With this integration, your ERP can manage electronic invoicing automatically.

--- a/docs/Guia_Integracion_ERP.es.md
+++ b/docs/Guia_Integracion_ERP.es.md
@@ -1,0 +1,97 @@
+# Guía de Integración con Sistemas ERP
+
+Esta guía describe los pasos generales para integrar **dgii-ecf** dentro de cualquier sistema ERP existente. Se asume que el ERP ya gestiona el ciclo de ventas y se desea automatizar el envío de comprobantes fiscales electrónicos (e-CF) a la DGII.
+
+## 1. Preparación del Entorno
+
+1. Instale la librería en el proyecto Node.js utilizado por su ERP:
+
+```bash
+npm install dgii-ecf
+```
+
+2. Asegúrese de contar con su certificado digital (.p12) y su contraseña.
+
+## 2. Carga del Certificado
+
+Utilice `P12Reader` para cargar la clave privada y el certificado que se empleará para firmar los XML.
+
+```ts
+import path from 'path';
+import { P12Reader } from 'dgii-ecf';
+
+const reader = new P12Reader('contraseña_certificado');
+const certs = reader.getKeyFromFile(path.resolve(__dirname, 'certificado.p12'));
+```
+
+## 3. Autenticación
+
+Antes de enviar documentos, obtenga un token válido frente a la DGII.
+
+```ts
+import { ECF } from 'dgii-ecf';
+
+const ecf = new ECF(certs);
+const tokenData = await ecf.authenticate();
+```
+
+Conserve el `tokenData.token` según la lógica de autenticación de su ERP y renuévelo cuando sea necesario.
+
+## 4. Firma y Envío de Documentos
+
+El ERP debe generar el XML de la factura o documento electrónico siguiendo el estándar de la DGII. Una vez generado, utilice `Signature` para firmarlo y `ECF` para enviarlo.
+
+```ts
+import fs from 'fs';
+import { Signature } from 'dgii-ecf';
+
+const xml = fs.readFileSync('factura.xml', 'utf8');
+const signature = new Signature(certs.key!, certs.cert!);
+const signedXml = signature.signXml(xml, 'ECF');
+
+const respuesta = await ecf.sendElectronicDocument(signedXml, 'RNCeNCF.xml');
+```
+
+Registre en su ERP el `trackId` y el estado de la respuesta para su posterior consulta.
+
+## 5. Consulta de Estado
+
+Para conocer el estado de un documento previamente enviado, utilice `statusTrackId`.
+
+```ts
+const estado = await ecf.statusTrackId(trackId);
+```
+
+Integre esta información en los módulos de seguimiento o reportes del ERP.
+
+## 6. Manejo de Respuestas y Errores
+
+- Valide las respuestas de cada operación y registre los códigos de error en el ERP.
+- Implemente reintentos o notificación al usuario en caso de fallos de red o respuestas inválidas.
+
+## 7. Entornos de DGII
+
+Configure el entorno adecuadamente según el ambiente (Desarrollo, Certificación o Producción).
+
+```ts
+import { ENVIRONMENT } from 'dgii-ecf';
+const ecf = new ECF(certs, ENVIRONMENT.PROD);
+```
+
+## 8. Buenas Prácticas
+
+- Mantenga la lógica de integración en un módulo independiente dentro del ERP.
+- Proteja la clave privada del certificado y limíte su acceso.
+- Automatice la renovación del token y el control de vencimiento de certificados.
+
+## 9. Ejemplo de Flujo Básico
+
+1. El usuario registra la factura en el ERP.
+2. El ERP genera el XML del e-CF.
+3. Se firma el XML con `Signature`.
+4. Se envía el documento con `ECF.sendElectronicDocument`.
+5. Se almacena la respuesta y el `trackId`.
+6. Se consulta periódicamente el estado con `statusTrackId` hasta recibir confirmación.
+
+Con esta integración, su ERP podrá gestionar la emisión electrónica de comprobantes de forma automática.
+


### PR DESCRIPTION
## Summary
- add a detailed ERP integration guide in Spanish and English
- link the new docs from README files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842eb14cef483299b51e233033e4896